### PR TITLE
Sort movies by title

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -2,7 +2,7 @@ class MoviesController < ApiController
 
   # GET /movies
   def index
-    @movies = Movie.all
+    @movies = Movie.all.sort_by(&:title)
     render json: @movies.to_json
   end
 


### PR DESCRIPTION
To make it easier to spot missing movies, this PR default sorts all movies to alphabetical by title.