### PR TITLE
Hotfix - Filter to Avoid Showing movies_tags

### DIFF
--- a/app/admin/movies.rb
+++ b/app/admin/movies.rb
@@ -8,6 +8,11 @@ ActiveAdmin.register Movie do
                 :movie_api_id,
                 tag_ids: []
 
+  filter :title
+  filter :year
+  filter :is_owned
+  filter :description
+
   form do |f| 
     f.inputs 'Required' do
       f.input :title, required: true, hint: "Please enter a title"

--- a/app/admin/tags.rb
+++ b/app/admin/tags.rb
@@ -1,3 +1,5 @@
 ActiveAdmin.register Tag do
   permit_params :name
+  
+  filter :name
 end


### PR DESCRIPTION
Because movies_tags is a join table without foreign keys, it can't be ordered or indexed -- this means that ActiveAdmin can't display every possible thing on Tags or Movies without some filter, or it'll try to display filters for movies_tags and blow up.