### PR TITLE
Add primary key to movies_tags, cleanup admin interface

### DIFF
--- a/app/admin/movies.rb
+++ b/app/admin/movies.rb
@@ -8,10 +8,21 @@ ActiveAdmin.register Movie do
                 :movie_api_id,
                 tag_ids: []
 
-  filter :title
-  filter :year
-  filter :is_owned
-  filter :description
+  index do |movie|
+      column :title
+      column :year
+      column "Director" do |movie|
+        movie.directors
+      end
+      column "Image" do |movie|
+        link_to image_tag(movie.image_url, height: 100), admin_movie_path(movie)
+      end
+      column :is_owned
+      column "Tags" do |movie|
+        movie.tags
+      end
+      actions
+  end
 
   form do |f| 
     f.inputs 'Required' do

--- a/app/admin/tags.rb
+++ b/app/admin/tags.rb
@@ -1,5 +1,3 @@
 ActiveAdmin.register Tag do
   permit_params :name
-  
-  filter :name
 end

--- a/app/models/movies_tag.rb
+++ b/app/models/movies_tag.rb
@@ -2,6 +2,7 @@
 #
 # Table name: movies_tags
 #
+#  id       :bigint           not null, primary key
 #  movie_id :bigint           not null
 #  tag_id   :bigint           not null
 #

--- a/db/migrate/20190526160631_add_primary_key_to_movies_tags.rb
+++ b/db/migrate/20190526160631_add_primary_key_to_movies_tags.rb
@@ -1,0 +1,5 @@
+class AddPrimaryKeyToMoviesTags < ActiveRecord::Migration[5.2]
+  def change
+    add_column :movies_tags, :id, :primary_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_24_005439) do
+ActiveRecord::Schema.define(version: 2019_05_26_160631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,7 +61,7 @@ ActiveRecord::Schema.define(version: 2019_05_24_005439) do
     t.integer "movie_api_id"
   end
 
-  create_table "movies_tags", id: false, force: :cascade do |t|
+  create_table "movies_tags", force: :cascade do |t|
     t.bigint "movie_id", null: false
     t.bigint "tag_id", null: false
     t.index ["movie_id"], name: "index_movies_tags_on_movie_id"


### PR DESCRIPTION
Essentially tidies up some work from the other day when I made the `movies_tags` table with the default join table setup in rails with no primary key, which meant nothing could order by a primary key, which meant these admin pages blew up without explicit filters. This adds a primary key and tidies the index view a little for movies and tags.