### PR TITLE
Create wishlist link and add to unowned movies

### DIFF
--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -48,6 +48,23 @@ class Movie < ApplicationRecord
     end
   end
 
+  def wishlist_link
+    generate_wishlist_link
+  end
+
+  def as_json(options={})
+    {
+      id: self.id,
+      title: self.title,
+      year: self.year,
+      is_owned: self.is_owned,
+      image_url: self.image_url,
+      description: self.description,
+      wishlist_link: self.wishlist_link,
+    }.merge(:directors => directors.as_json)
+      .merge(:tags => tags.as_json)
+  end
+
   private
 
   def get_movie_from_api_id
@@ -79,5 +96,9 @@ class Movie < ApplicationRecord
       result["release_date"][0..3] == year.to_s
     end
     results_by_year.first
+  end
+
+  def generate_wishlist_link
+    WishlistLink.new(title).generate
   end
 end

--- a/app/services/wishlist_link.rb
+++ b/app/services/wishlist_link.rb
@@ -1,0 +1,14 @@
+class WishlistLink
+  attr_reader :term
+
+  BASE_URL = "https://www.amazon.com/"
+  
+  def initialize(term)
+    @term = term
+  end
+
+  def generate
+    search_string = term.downcase.split(" ").join("+")
+    BASE_URL + "s?k=#{search_string}&i=movies-tv&ref=nb_sb_noss"
+  end
+end

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -201,6 +201,7 @@ class App extends Component {
                       }
                   </Item.Meta>
                 <MovieDescription description={movies[key].description} />
+                <WishlistLink link="http://www.amazon.com" wishlist_link={movies[key].wishlist_link} is_owned={movies[key].is_owned} />
                 <Divider hidden section />
                 {movies[key].tags.length > 0 && 
                   movies[key].tags.map((tag) => {
@@ -240,6 +241,20 @@ class MovieImage extends Component {
       );
     } else {
       return (<Item.Image src={this.props.image_url} />);
+    }
+  }
+}
+
+class WishlistLink extends Component {
+  render() {
+    if (this.props.is_owned) {
+      return (
+        ""
+      )
+    } else {
+      return (
+        <Label as='a' color="yellow" href={this.props.wishlist_link} >Add to Wishlist</Label>
+      )
     }
   }
 }


### PR DESCRIPTION
This PR adds a new class to generate Amazon search links based on a movie's title. A button with this link will populate on any movie where `is_owned` is `false`, allowing us to quickly and easily add movies to our collection's wishlist.