### PR TITLE
Setup NewRelic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,9 @@ gem 'activeadmin'
 
 gem 'httparty'
 
+#Use NewRelic for performance monitoring
+gem 'newrelic_rpm'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,7 @@ GEM
     msgpack (1.2.10)
     multi_xml (0.6.0)
     multiprocessing (0.0.2)
+    newrelic_rpm (6.5.0.357)
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
@@ -258,6 +259,7 @@ DEPENDENCIES
   dotenv-rails
   httparty
   listen (>= 3.0.5, < 3.2)
+  newrelic_rpm
   pg (>= 0.18, < 2.0)
   pgsync
   pry

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,0 +1,45 @@
+#
+# This file configures the New Relic Agent.  New Relic monitors Ruby, Java,
+# .NET, PHP, Python, Node, and Go applications with deep visibility and low
+# overhead.  For more information, visit www.newrelic.com.
+#
+# Generated July 19, 2019
+#
+# This configuration file is custom generated for app134207757@heroku.com
+#
+# For full documentation of agent configuration options, please refer to
+# https://docs.newrelic.com/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration
+
+common: &default_settings
+  # Required license key associated with your New Relic account.
+  license_key: ENV.fetch["NEW_RELIC_LICENSE_KEY"]
+
+  # Your application name. Renaming here affects where data displays in New
+  # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications
+  app_name: Movie Wolf
+
+  # To disable the agent regardless of other settings, uncomment the following:
+  # agent_enabled: false
+
+  # Logging level for log/newrelic_agent.log
+  log_level: info
+
+
+# Environment-specific settings are in this section.
+# RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.
+# If your application has other named environments, configure them here.
+development:
+  <<: *default_settings
+  app_name: Movie Wolf (Development)
+
+test:
+  <<: *default_settings
+  # It doesn't make sense to report to New Relic from automated test runs.
+  monitor_mode: false
+
+staging:
+  <<: *default_settings
+  app_name: Movie Wof (Staging)
+
+production:
+  <<: *default_settings

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -12,7 +12,7 @@
 
 common: &default_settings
   # Required license key associated with your New Relic account.
-  license_key: ENV.fetch("NEW_RELIC_LICENSE_KEY")
+  license_key: 41df1300d856a6a516ee9f8bd98276eb46ee57ed
 
   # Your application name. Renaming here affects where data displays in New
   # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -12,7 +12,7 @@
 
 common: &default_settings
   # Required license key associated with your New Relic account.
-  license_key: ENV.fetch["NEW_RELIC_LICENSE_KEY"]
+  license_key: ENV.fetch("NEW_RELIC_LICENSE_KEY")
 
   # Your application name. Renaming here affects where data displays in New
   # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications


### PR DESCRIPTION
To reduce the time the site's idling (and thus in danger of shutdown on the hobby tier), this PR adds NewRelic, which will ping the site at intervals, keeping it awake and giving us usage data.