### PR TITLE
#31 - Filter movies by title

### DIFF
--- a/client/src/movielist.js
+++ b/client/src/movielist.js
@@ -1,10 +1,51 @@
 import React, { Component } from 'react'
-import { Container, Item } from 'semantic-ui-react'
+import { Container, Item, Input } from 'semantic-ui-react'
 import MovieCard from './moviecard.js'
 
 class MovieList extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      filtered_movies: []
+    }
+    this.handleChange = this.handleChange.bind(this)
+  }
+
+  componentDidMount() {
+    this.setState({
+      filtered_movies: this.props.movies
+    });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      filtered_movies: nextProps.movies
+    });
+  }
+
+  handleChange(e) {
+    let currentList = [];
+    let filteredList = [];
+
+    if (e.target.value !== "") {
+      currentList = this.props.movies;
+
+      filteredList = currentList.filter(movie => {
+        const lc = movie.title.toLowerCase();
+        const filter = e.target.value.toLowerCase();
+        return lc.includes(filter);
+      });
+    } else {
+      filteredList = this.props.movies;
+    }
+
+    this.setState({
+      filtered_movies: filteredList
+    });
+  }
   render() {
-    const movies = this.props.movies
+    const movies = this.state.filtered_movies
     const getYearMovies = this.props.getYearMovies
     const getDirectorMovies = this.props.getDirectorMovies
     const getFilteredMovies = this.props.getFilteredMovies
@@ -12,6 +53,7 @@ class MovieList extends Component {
     if (movies && movies.length) {
       return (
         <Item.Group divided unstackable>
+          <Input fluid icon='search' onChange={this.handleChange} placeholder='Search...' />
           {Object.keys(movies).map((key) => (
             <MovieCard key={key} movie={movies[key]} getYearMovies={getYearMovies} getDirectorMovies={getDirectorMovies} getFilteredMovies={getFilteredMovies} />
           ))}

--- a/client/src/movielist.js
+++ b/client/src/movielist.js
@@ -7,20 +7,20 @@ class MovieList extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      filtered_movies: []
+      filteredMovies: []
     }
     this.handleChange = this.handleChange.bind(this)
   }
 
   componentDidMount() {
     this.setState({
-      filtered_movies: this.props.movies
+      filteredMovies: this.props.movies
     });
   }
 
   componentWillReceiveProps(nextProps) {
     this.setState({
-      filtered_movies: nextProps.movies
+      filteredMovies: nextProps.movies
     });
   }
 
@@ -41,11 +41,12 @@ class MovieList extends Component {
     }
 
     this.setState({
-      filtered_movies: filteredList
+      filteredMovies: filteredList
     });
   }
+
   render() {
-    const movies = this.state.filtered_movies
+    const movies = this.state.filteredMovies
     const getYearMovies = this.props.getYearMovies
     const getDirectorMovies = this.props.getDirectorMovies
     const getFilteredMovies = this.props.getFilteredMovies


### PR DESCRIPTION
Closes #31.

This PR adds a live search filter bar. I worked off of [this tutorial](https://dev.to/iam_timsmith/lets-build-a-search-bar-in-react-120j) but essentially what we're doing is in the `MovieList` component, now instead of rendering with the `movies` prop as passed in from the app, we make a copy of that by default as `filteredMovies`. There's also a search bar with an `onChange` handler. If this is ever changed to not blank, we run the `handleChange` function, which looks at the current value turned to lower case and compares it to every movie title in the current `filtered_movies` state, returning only those which return `true` and filtering `filteredMovies` to a smaller collection.