### PR TITLE
Refactor sorts

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Container,  Menu, Image, Dimmer, Loader, Divider } from 'semantic-ui-react'
+import { Container, Icon, Menu, Image, Dimmer, Loader, Divider } from 'semantic-ui-react'
 import DirectorBox from './directorbox.js'
 import SuggestedMovie from './suggestedmovie.js'
 import MovieList from './movielist.js'
@@ -99,7 +99,7 @@ class App extends Component {
   }
 
   clearFilters () {
-    this.setState({director: "", suggestedMovie:""})
+    this.setState({director: "", suggestedMovie:"", currentSort:""})
     this.getOwnedMovies()
   }
 
@@ -116,9 +116,86 @@ class App extends Component {
       })
   }
 
+  // function for dynamic sorting
+  compareValues(key, order='asc') {
+    return function(a, b) {
+      if(!a.hasOwnProperty(key) || !b.hasOwnProperty(key)) {
+        // property doesn't exist on either object
+        return 0;
+      }
+  
+      const varA = (typeof a[key] === 'string') ?
+        a[key].toUpperCase() : a[key];
+      const varB = (typeof b[key] === 'string') ?
+        b[key].toUpperCase() : b[key];
+  
+      let comparison = 0;
+      if (varA > varB) {
+        comparison = 1;
+      } else if (varA < varB) {
+        comparison = -1;
+      }
+      return (
+        (order === 'desc') ? (comparison * -1) : comparison
+      );
+    };
+  }
+
+
+  getAlphaSortMovies(order='asc') {
+    let currentMovies = [];
+    let sortedMovies = [];
+    const currentSort = this.state.currentSort;
+
+    currentMovies = this.state.movies;
+
+    if (currentSort === "alpha_asc") {
+      order = 'desc'
+    }
+    sortedMovies = currentMovies.sort(this.compareValues('title', order))
+
+    this.setState({
+      movies: sortedMovies,
+      currentSort: "alpha_" + order
+    });
+  }
+
+  getChronoSortMovies(order='asc') { 
+    let currentMovies = [];
+    let sortedMovies = [];
+    const currentSort = this.state.currentSort;
+
+    currentMovies = this.state.movies;
+
+    if (currentSort === "chrono_asc") { 
+      order = 'desc'
+    }
+    sortedMovies = currentMovies.sort(this.compareValues('year', order))
+
+    this.setState({
+      movies: sortedMovies,
+      currentSort: "chrono_" + order
+    });
+  }
+
   getMovie (id) {
     this.fetch(`/api/movies/${id}`)
       .then(movie => this.setState({movie: movie}))
+  }
+
+  getIconForSort (sortPrefix) {
+    let currentSort = this.state.currentSort;
+    let arrowDown = "long arrow alternate down"
+    let arrowUp = "long arrow alternate up"
+    if (!currentSort) {
+      return arrowUp
+    }
+    
+    if (currentSort.includes(sortPrefix) && currentSort.includes("asc")) {
+      return arrowDown
+    } else {
+      return arrowUp
+    }
   }
 
   render () {
@@ -126,19 +203,18 @@ class App extends Component {
     return movies
       ? <Container text>
         <Image src='https://s3.amazonaws.com/movie-wolf/MovieWolfLogo.png' size='medium' centered />
+        <Divider hidden section />
+        <SuggestedMovie movie={suggestedMovie} getYearMovies={this.getYearMovies} getDirectorMovies={this.getDirectorMovies} getFilteredMovies={this.getFilteredMovies} />
+        <DirectorBox director={director} />
         <Container>
         <Divider hidden section />
         <Menu color='red' inverted stackable>
-          <Menu.Item onClick={() => this.getMovies()}>Alphabetical</Menu.Item>
-          <Menu.Item onClick={() => this.getSortedMovies("chrono")}>Chronological</Menu.Item>
-          <Menu.Item onClick={() => this.getSortedMovies("chrono-rev")}>Reverse Chronological</Menu.Item>
+          <Menu.Item onClick={() => this.getAlphaSortMovies()}>Alphabetical<Icon name={this.getIconForSort("alpha")} /></Menu.Item>
+          <Menu.Item onClick={() => this.getChronoSortMovies()}>Chronological<Icon name={this.getIconForSort("chrono")} /></Menu.Item>
           <Menu.Item onClick={() => this.getSuggestedMovie()}>Take It To The Wolf</Menu.Item>
           <Menu.Item onClick={() => this.clearFilters()}>Clear Filters</Menu.Item>
         </Menu>
         </Container>
-        <Divider hidden section />
-        <SuggestedMovie movie={suggestedMovie} getYearMovies={this.getYearMovies} getDirectorMovies={this.getDirectorMovies} getFilteredMovies={this.getFilteredMovies} />
-        <DirectorBox director={director} />
         <MovieList movies={movies} getYearMovies={this.getYearMovies} getDirectorMovies={this.getDirectorMovies} getFilteredMovies={this.getFilteredMovies} />
       </Container>
       : <Container text>


### PR DESCRIPTION
Closes #39.
Closes #40.

This PR swaps the chronological and alphabetical sort buttons from hitting the API to get back sorted information to instead sort the `movies` state on the frontend. This makes everything a little quicker and, as a bonus, allows the user to control the sort on other filtered movie states. 

This PR also makes the alphabetical and chronological buttons into toggles that flip from ascending to descending depending on state.